### PR TITLE
Remove HTTP GET restriction for Authorization token

### DIFF
--- a/module/Public/Invoke-nbApi.ps1
+++ b/module/Public/Invoke-nbApi.ps1
@@ -105,7 +105,7 @@ function Invoke-nbApi {
                 ###MaximumRedirection
                 ###TransferEncoding
             }
-            if ($Script:Token -and $HttpVerb -ne $get) {
+            if ($Script:Token) {
                 $unmanagedString = $marshal::SecureStringToGlobalAllocUnicode($Script:Token)
                 $Params['Headers'] = @{
                     Authorization = "token {0}" -f $marshal::PtrToStringUni($unmanagedString)


### PR DESCRIPTION
Executing an HTTP GET request against the Netbox API requires an authorization token. Passing the auth token in the request was excluded for GET requests. Removed this exclusion solved my problem where I wasn't able to perform any Get-requests through powerbox.