### PR TITLE
Added support for ports in APIUrl

### DIFF
--- a/module/Public/Invoke-nbApi.ps1
+++ b/module/Public/Invoke-nbApi.ps1
@@ -96,6 +96,7 @@ function Invoke-nbApi {
                 Host   = $_APIUrl.DnsSafeHost
                 Path   = $_APIUrl.LocalPath.TrimEnd('/') + '/' + $Resource
                 Query  = $QueryString
+                Port   = $_APIUrl.Port
             }
         } else {
             $URI = [UriBuilder]::new($rawUrl)


### PR DESCRIPTION
With this change you can have an APIUrl that specifies a port (e. g. http://netbox.example.com:8000/api). Prior to this change the server would return an 'internal server error' with this url.
Tested with and without specifying a port.