### PR TITLE
Stop it turning https: into httpss: then breaking.

### DIFF
--- a/module/Public/Get-nbObject.ps1
+++ b/module/Public/Get-nbObject.ps1
@@ -86,7 +86,7 @@ function Get-nbObject {
         while (![string]::IsNullOrEmpty($object.next)) {
             Write-Verbose $object.next
             $url = if ($APIUrl.Scheme -eq 'https' -or $Script:APIUrl.Scheme -eq 'https') {
-                $object.next -replace 'http','https'
+                $object.next -replace '^http:', 'https:'
             } else {
                 $object.next
             }


### PR DESCRIPTION
My .Next already has https at the start, and this was making it httpss, and then throwing errors. 
Changed the regex to only match a complete `http:` at the start of the string.