### PR TITLE
Modified property value tests

### DIFF
--- a/module/Public/Set-nbObject.ps1
+++ b/module/Public/Set-nbObject.ps1
@@ -98,8 +98,15 @@ function Set-nbObject {
     :maploop foreach ($property in $object.psobject.properties) {
         $Name = $Property.name -replace '-' -replace ':'
         $value = $Property.value
-        if ($Patch.IsPresent -and $OldObject."$name" -eq $value) {
-            continue :maploop
+        if ($Patch.IsPresent) {
+            if( [string]::IsNullOrEmpty( $($OldObject."$name") ) -and [string]::IsNullOrEmpty($value) ) {
+                Write-Verbose "Bypassing property $name (values are empty)"
+                continue :maploop
+            }
+            If( ($OldObject."$name" -eq $value) -and ( $object."$name" -isnot [System.Array]) ) {
+                Write-Verbose "Bypassing property $name (Values are similar and object isn't an array)"
+                continue :maploop
+            }
         }
         if ($name -in $lookup.keys) {
             $value = ConvertTo-nbID -source $value -value $name
@@ -109,6 +116,7 @@ function Set-nbObject {
         } elseif ($name -eq 'custom_fields') {
             $mapObject.custom_fields += $value
         } else {
+            Write-Verbose "Adding property $name"
             $mapObject[$name] = $value
         }
     }


### PR DESCRIPTION
Hi,

I added a few more tests during the construction of the object as it was impossible to remove correctly an array of tags on a device.
The simple "-eq" would always return true when hitting an array.
e.g.
```
     [oldobject]             [newobject]
@('tagtest','tagtest2') -eq @('tagtest2')
tagtest2
```
Although a tag is removed, the code will continue back to `:maploop` since the condition returns an element, skipping the modification.
I tried to avoid being too aggressive and keep the original logic of the IF condition.

Thanks,
Wes.