### PR TITLE
Fix: Issues with International Characters like german umlaut

### DIFF
--- a/module/Public/New-nbObject.ps1
+++ b/module/Public/New-nbObject.ps1
@@ -82,5 +82,7 @@ function New-nbObject {
     }
     $mapObject = New-Object -TypeName psobject -Property $mapObject
 
-    Invoke-nbApi -Resource $Resource -HttpVerb POST -Body ($mapObject | ConvertTo-Json -Compress)
+    $jsondata=($mapObject | ConvertTo-Json)
+    #Issues with International Characters like German Umlaut -> so [System.Text.Encoding]::UTF8
+    Invoke-nbApi -Resource $Resource -HttpVerb POST -Body ([System.Text.Encoding]::UTF8.GetBytes($jsondata))
 }

--- a/module/Public/Set-nbObject.ps1
+++ b/module/Public/Set-nbObject.ps1
@@ -121,10 +121,13 @@ function Set-nbObject {
         }
     }
     $mapObject = New-Object -TypeName psobject -Property $mapObject
+    $jsondata=($mapObject | ConvertTo-Json)
     if ($Patch.IsPresent) {
         #$notChanged = $mapObject | compare-object -ReferenceObject $OldObject -ExcludeDifferent -PassThru
         #$mapObject = $mapObject | Select-Object -ExcludeProperty $notChanged
-        return Invoke-nbApi -Resource $Resource/$id -HttpVerb Patch -Body ($mapObject | ConvertTo-Json)
+        #Issues with International Characters like German Umlaut -> so [System.Text.Encoding]::UTF8
+        return Invoke-nbApi -Resource $Resource/$id -HttpVerb Patch -Body ([System.Text.Encoding]::UTF8.GetBytes($jsondata))
     }
-    return Invoke-nbApi -Resource $Resource/$id -HttpVerb Put -Body ($mapObject | ConvertTo-Json)
+    #Issues with International Characters like German Umlaut -> so [System.Text.Encoding]::UTF8
+    return Invoke-nbApi -Resource $Resource/$id -HttpVerb Put -Body ([System.Text.Encoding]::UTF8.GetBytes($jsondata))
 }


### PR DESCRIPTION
Fixes issue with german Umlauts (and other non english characters) when using in strings in Set-nbObject and New-nbObject. 
For example like this

```
$nbVMObject= New-Object -Type PSObject -Property @{
	name="VMName"
	status="active"
	site="Datacenter in Brühl"
	cluster=1
	role=1
	vcpus=2
	memory=1024
	disk=10
	comments="Beschreibung für ein deusches System mit deutschn Umlauten äöüÄÖÜ"
}

New-nbVirtualMachine -Object $nbVMObject
```